### PR TITLE
Added lighting options that can be configured from the Dock

### DIFF
--- a/addons/gridmap-plus/dock/Dock.gd
+++ b/addons/gridmap-plus/dock/Dock.gd
@@ -5,22 +5,56 @@ extends VBoxContainer
 @onready var alignment_mode: OptionButton = %AlignmentMode
 @onready var hotbar_mode: OptionButton = %HotbarMode
 
+@onready var light_position: LineEdit = %LightPosition
+@onready var light_rotation: LineEdit = %LightRotation
+@onready var light_energy: HSlider = %LightEnergy
+@onready var light_indirect_energy: HSlider = %LightIndirectEnergy
+@onready var light_angular_distance: HSlider = %LightAngularDistance
+
+var light_type = "directional"
+var directional_light = {}
+var omni_light = {}
+
+var window = null
+
 var grid_map : GridMap = null:
 	set(x):
 		grid_map = x
-		%PanelContents.hide()
+		%MeshOptions.hide()
 
 var _selected : int = -1
 var _mesh_palette : ItemList
 
 
 func _ready() -> void:
+	
 	var grid_map_editor = EditorInterface.get_base_control().find_children("*", "GridMapEditor", true, false)
 	if grid_map_editor.size() != 1:
 		return
 	
 	_mesh_palette = grid_map_editor[0].get_children()[-1]
 	_mesh_palette.item_selected.connect(_on_palette_item_selected)
+	
+	# These values are used to restore the previous input field value in case of bad user input
+	directional_light["last_valid_position_value"] = light_position.text
+	directional_light["last_valid_rotation_value"] = light_rotation.text
+	omni_light["last_valid_position_value"] = light_position.text
+	omni_light["last_valid_rotation_value"] = light_rotation.text
+	
+	# We initialize the values for each of the light types
+	var light_initial_position = parse_vector3(light_position.text)[1]
+	var light_initial_rotation = parse_vector3(light_rotation.text)[1]
+	
+	directional_light["chosen_position"] = light_initial_position
+	directional_light["chosen_rotation"] = light_initial_rotation
+	directional_light["chosen_energy"] = light_energy.value
+	directional_light["chosen_indirect_energy"] = light_indirect_energy.value
+	directional_light["chosen_angular_distance"] = light_angular_distance.value
+	
+	omni_light["chosen_position"] = light_initial_position
+	omni_light["chosen_rotation"] = light_initial_rotation
+	omni_light["chosen_energy"] = light_energy.value
+	omni_light["chosen_indirect_energy"] = light_indirect_energy.value
 
 
 func _on_build_button_pressed() -> void:
@@ -31,7 +65,7 @@ func _on_build_button_pressed() -> void:
 	# if the scene were open in the editor, generating a huge amount of error spam.
 	# However, it specifically needs to be run in the editor, so the best way to
 	# approach this is to manually build the scene when the editor is opened.
-	var window = Window.new()
+	window = Window.new()
 	window.set_script(load("res://addons/gridmap-plus/dock/Build.gd"))
 	window.set_grid_map(grid_map)
 	window.size = get_window().size - 100 * Vector2i.ONE
@@ -39,10 +73,45 @@ func _on_build_button_pressed() -> void:
 		window.write_changes(grid_map)
 		EditorInterface.mark_scene_as_unsaved()
 	)
-	EditorInterface.popup_dialog_centered(window)
 	
+	window.builder_ready.connect(_on_builder_window_ready)
+	
+	EditorInterface.popup_dialog_centered(window)
+		
 	await window.visibility_changed
 	build_button.disabled = false
+
+
+func _on_builder_window_ready() -> void:
+	
+	_set_builder_light_parameters()
+	
+	# Disconnect the signal to avoid multiple calls
+	window.builder_ready.disconnect(_on_builder_window_ready)
+
+
+func _set_builder_light_parameters() -> void:
+	
+	if window == null:
+		return
+	
+		# Set the light parameters after the builder window is ready
+	if light_type == "directional":
+		window.set_light_parameters(
+			"directional",
+			directional_light["chosen_position"],
+			directional_light["chosen_rotation"],
+			directional_light["chosen_energy"],
+			directional_light["chosen_indirect_energy"],
+			directional_light["chosen_angular_distance"])
+	elif light_type == "omni":
+		window.set_light_parameters(
+			"omni",
+			omni_light["chosen_position"],
+			omni_light["chosen_rotation"],
+			omni_light["chosen_energy"],
+			omni_light["chosen_indirect_energy"],
+			0.0)
 
 
 func _on_palette_item_selected(item: int) -> void:
@@ -50,7 +119,7 @@ func _on_palette_item_selected(item: int) -> void:
 	if !grid_map:
 		return
 	
-	%PanelContents.show()
+	%MeshOptions.show()
 	%ItemImage.texture = _mesh_palette.get_item_icon(item)
 	%ItemName.text = _mesh_palette.get_item_text(item)
 	
@@ -77,3 +146,139 @@ func _on_hotbar_mode_item_selected(index: int) -> void:
 		10: hotbar = 0
 		_: hotbar = index
 	GridMapPlus.set_hotbar(grid_map.mesh_library, _selected, hotbar)
+
+
+func _on_light_type_item_selected(index: int) -> void:
+	if index == 0:
+		light_type = "directional"
+		%LightAngularDistanceLabel.visible = true
+		%LightAngularDistance.visible = true
+		light_position.text = directional_light["last_valid_position_value"]
+		light_rotation.text = directional_light["last_valid_rotation_value"]
+		light_energy.value = directional_light["chosen_energy"]
+		light_indirect_energy.value = directional_light["chosen_indirect_energy"]
+		light_angular_distance.value = directional_light["chosen_angular_distance"]
+		
+	elif index == 1:
+		light_type = "omni"
+		%LightAngularDistanceLabel.visible = false
+		%LightAngularDistance.visible = false
+		light_position.text = omni_light["last_valid_position_value"]
+		light_rotation.text = omni_light["last_valid_rotation_value"]
+		light_energy.value = omni_light["chosen_energy"]
+		light_indirect_energy.value = omni_light["chosen_indirect_energy"]
+		
+	_set_builder_light_parameters()
+
+
+func _on_light_position_focus_exited() -> void:
+	
+	_check_and_change_light_position(light_position.text)
+
+
+func _on_light_rotation_focus_exited() -> void:
+	
+	_check_and_change_light_rotation(light_rotation.text)
+
+
+func _on_light_position_text_submitted(new_text: String) -> void:
+	
+	_check_and_change_light_position(new_text)
+
+	
+
+func _on_light_rotation_text_submitted(new_text: String) -> void:
+	
+	_check_and_change_light_rotation(new_text)
+
+
+func _check_and_change_light_position(new_text: String) -> void:
+	var result = parse_vector3(new_text)
+	
+	if result[0]:# If parsing was successful
+		var parsed_vector: Vector3 = result[1]
+		if light_type == "directional":
+			directional_light["last_valid_position_value"] = new_text
+			directional_light["chosen_position"] = parsed_vector
+		elif light_type == "omni":
+			omni_light["last_valid_position_value"] = new_text
+			omni_light["chosen_position"] = parsed_vector
+		light_position.release_focus()
+		_set_builder_light_parameters()
+	else:
+		# Invalid input
+		if light_type == "directional":
+			light_position.text = directional_light["last_valid_position_value"]
+		elif light_type == "omni":
+			light_position.text = omni_light["last_valid_position_value"]
+
+
+func _check_and_change_light_rotation(new_text: String) -> void:
+	var result = parse_vector3(new_text)
+	
+	if result[0]:# If parsing was successful
+		var parsed_vector: Vector3 = result[1]
+		if light_type == "directional":
+			directional_light["last_valid_rotation_value"] = new_text
+			directional_light["chosen_rotation"] = parsed_vector
+		elif light_type == "omni":
+			omni_light["last_valid_rotation_value"] = new_text
+			omni_light["chosen_rotation"] = parsed_vector
+		light_rotation.release_focus()
+		_set_builder_light_parameters()
+	else:
+		# Invalid input
+		if light_type == "directional":
+			light_rotation.text = directional_light["last_valid_rotation_value"]
+		elif light_type == "omni":
+			light_rotation.text = omni_light["last_valid_rotation_value"]
+
+
+func _on_light_energy_drag_ended(value_changed: bool) -> void:
+	if value_changed:
+		if light_type == "directional":
+			directional_light["chosen_energy"] = light_energy.value
+		elif light_type == "omni":
+			omni_light["chosen_energy"] = light_energy.value
+	_set_builder_light_parameters()
+	
+
+func _on_light_indirect_energy_drag_ended(value_changed: bool) -> void:
+	pass # Replace with function body.
+	if value_changed:
+		if light_type == "directional":
+			directional_light["chosen_indirect_energy"] = light_indirect_energy.value
+		elif light_type == "omni":
+			omni_light["chosen_indirect_energy"] = light_indirect_energy.value
+	_set_builder_light_parameters()
+	
+
+func _on_light_angular_distance_drag_ended(value_changed: bool) -> void:
+	if value_changed:
+		directional_light["chosen_angular_distance"] = light_angular_distance.value
+	_set_builder_light_parameters()
+	
+
+func parse_vector3(input: String) -> Array:
+	# Remove parentheses if present
+	input = input.strip_edges().trim_prefix("(").trim_suffix(")")
+	
+	# Split the string by comma or space
+	var parts = input.split(",")
+	if parts.size() != 3:
+		parts = input.split(" ")
+		
+	if parts.size() != 3:
+		return [false, Vector3.ZERO]
+	
+	for i in parts:
+		i = i.strip_edges()
+		if not i.is_valid_float():
+			return [false, Vector3.ZERO]
+	
+	var x = parts[0].to_float()
+	var y = parts[1].to_float()
+	var z = parts[2].to_float()
+	
+	return [true, Vector3(x,y,z)]
+	

--- a/addons/gridmap-plus/dock/Dock.tscn
+++ b/addons/gridmap-plus/dock/Dock.tscn
@@ -1,7 +1,12 @@
-[gd_scene load_steps=3 format=3 uid="uid://dlcingyoys2kd"]
+[gd_scene load_steps=4 format=3 uid="uid://dlcingyoys2kd"]
 
 [ext_resource type="Script" path="res://addons/gridmap-plus/dock/Dock.gd" id="1_bn7c7"]
 [ext_resource type="Texture2D" uid="uid://c7o451hql58hh" path="res://addons/gridmap-plus/assets/icons/Build.svg" id="2_ldijc"]
+
+[sub_resource type="StyleBoxLine" id="StyleBoxLine_x3fa8"]
+color = Color(0.389287, 0.389287, 0.389287, 1)
+thickness = 2
+vertical = true
 
 [node name="Dock" type="VBoxContainer"]
 custom_minimum_size = Vector2(0, 180)
@@ -34,36 +39,150 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="Panel/PanelContents"]
+[node name="GeneralOptions" type="MarginContainer" parent="Panel/PanelContents"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/PanelContents/GeneralOptions"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Panel/PanelContents/GeneralOptions/VBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.988235, 0.498039, 0.498039, 1)
+text = "General Options"
+
+[node name="GridContainer" type="GridContainer" parent="Panel/PanelContents/GeneralOptions/VBoxContainer"]
+layout_mode = 2
+theme_override_constants/h_separation = 10
+theme_override_constants/v_separation = 10
+columns = 2
+
+[node name="Label6" type="Label" parent="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer"]
+layout_mode = 2
+text = "Light Type"
+
+[node name="LightType" type="OptionButton" parent="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+selected = 0
+item_count = 2
+popup/item_0/text = "Directional"
+popup/item_1/text = "Omni"
+popup/item_1/id = 1
+
+[node name="Label" type="Label" parent="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer"]
+layout_mode = 2
+text = "Light Position"
+
+[node name="LightPosition" type="LineEdit" parent="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "4.0, 5.0, 3.0"
+expand_to_text_length = true
+
+[node name="Label2" type="Label" parent="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer"]
+layout_mode = 2
+text = "Light Rotation
+"
+
+[node name="LightRotation" type="LineEdit" parent="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "-45, 53.1301, 0"
+expand_to_text_length = true
+
+[node name="Label3" type="Label" parent="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer"]
+layout_mode = 2
+text = "Light Energy"
+
+[node name="LightEnergy" type="HSlider" parent="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 1
+max_value = 16.0
+step = 0.1
+value = 1.0
+
+[node name="Label4" type="Label" parent="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer"]
+layout_mode = 2
+text = "Light Indirect Energy"
+
+[node name="LightIndirectEnergy" type="HSlider" parent="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 1
+max_value = 16.0
+step = 0.1
+value = 1.0
+
+[node name="LightAngularDistanceLabel" type="Label" parent="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Light Angular Distance"
+
+[node name="LightAngularDistance" type="HSlider" parent="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 1
+max_value = 90.0
+
+[node name="VSeparator" type="VSeparator" parent="Panel/PanelContents"]
+layout_mode = 2
+theme_override_styles/separator = SubResource("StyleBoxLine_x3fa8")
+
+[node name="MeshOptions" type="MarginContainer" parent="Panel/PanelContents"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/PanelContents/MeshOptions"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Panel/PanelContents/MeshOptions/VBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.988235, 0.498039, 0.498039, 1)
+text = "Mesh Options"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Panel/PanelContents/MeshOptions/VBoxContainer"]
+layout_mode = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel/PanelContents/MeshOptions/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 theme_override_constants/margin_left = 20
 theme_override_constants/margin_top = 20
 theme_override_constants/margin_right = 20
 theme_override_constants/margin_bottom = 20
 
-[node name="VBox" type="VBoxContainer" parent="Panel/PanelContents/MarginContainer"]
+[node name="VBox" type="VBoxContainer" parent="Panel/PanelContents/MeshOptions/VBoxContainer/HBoxContainer/MarginContainer"]
 layout_mode = 2
 
-[node name="ItemImage" type="TextureRect" parent="Panel/PanelContents/MarginContainer/VBox"]
+[node name="ItemImage" type="TextureRect" parent="Panel/PanelContents/MeshOptions/VBoxContainer/HBoxContainer/MarginContainer/VBox"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(64, 64)
 layout_mode = 2
 
-[node name="ItemName" type="Label" parent="Panel/PanelContents/MarginContainer/VBox"]
+[node name="ItemName" type="Label" parent="Panel/PanelContents/MeshOptions/VBoxContainer/HBoxContainer/MarginContainer/VBox"]
 unique_name_in_owner = true
 layout_mode = 2
 text = "ItemName"
 horizontal_alignment = 1
 
-[node name="GridContainer" type="GridContainer" parent="Panel/PanelContents"]
+[node name="GridContainer" type="GridContainer" parent="Panel/PanelContents/MeshOptions/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 columns = 2
 
-[node name="Label" type="Label" parent="Panel/PanelContents/GridContainer"]
+[node name="Label" type="Label" parent="Panel/PanelContents/MeshOptions/VBoxContainer/HBoxContainer/GridContainer"]
 layout_mode = 2
 text = "Placement mode"
 
-[node name="AlignmentMode" type="OptionButton" parent="Panel/PanelContents/GridContainer"]
+[node name="AlignmentMode" type="OptionButton" parent="Panel/PanelContents/MeshOptions/VBoxContainer/HBoxContainer/GridContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 item_count = 5
@@ -77,11 +196,11 @@ popup/item_3/id = 3
 popup/item_4/text = "Fully random"
 popup/item_4/id = 4
 
-[node name="Label2" type="Label" parent="Panel/PanelContents/GridContainer"]
+[node name="Label2" type="Label" parent="Panel/PanelContents/MeshOptions/VBoxContainer/HBoxContainer/GridContainer"]
 layout_mode = 2
 text = "Hotbar shortcut"
 
-[node name="HotbarMode" type="OptionButton" parent="Panel/PanelContents/GridContainer"]
+[node name="HotbarMode" type="OptionButton" parent="Panel/PanelContents/MeshOptions/VBoxContainer/HBoxContainer/GridContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 selected = 0
@@ -109,5 +228,13 @@ popup/item_10/text = "0"
 popup/item_10/id = 10
 
 [connection signal="pressed" from="Toolbar/BuildButton" to="." method="_on_build_button_pressed"]
-[connection signal="item_selected" from="Panel/PanelContents/GridContainer/AlignmentMode" to="." method="_on_alignment_mode_item_selected"]
-[connection signal="item_selected" from="Panel/PanelContents/GridContainer/HotbarMode" to="." method="_on_hotbar_mode_item_selected"]
+[connection signal="item_selected" from="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer/LightType" to="." method="_on_light_type_item_selected"]
+[connection signal="focus_exited" from="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer/LightPosition" to="." method="_on_light_position_focus_exited"]
+[connection signal="text_submitted" from="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer/LightPosition" to="." method="_on_light_position_text_submitted"]
+[connection signal="focus_exited" from="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer/LightRotation" to="." method="_on_light_rotation_focus_exited"]
+[connection signal="text_submitted" from="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer/LightRotation" to="." method="_on_light_rotation_text_submitted"]
+[connection signal="drag_ended" from="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer/LightEnergy" to="." method="_on_light_energy_drag_ended"]
+[connection signal="drag_ended" from="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer/LightIndirectEnergy" to="." method="_on_light_indirect_energy_drag_ended"]
+[connection signal="drag_ended" from="Panel/PanelContents/GeneralOptions/VBoxContainer/GridContainer/LightAngularDistance" to="." method="_on_light_angular_distance_drag_ended"]
+[connection signal="item_selected" from="Panel/PanelContents/MeshOptions/VBoxContainer/HBoxContainer/GridContainer/AlignmentMode" to="." method="_on_alignment_mode_item_selected"]
+[connection signal="item_selected" from="Panel/PanelContents/MeshOptions/VBoxContainer/HBoxContainer/GridContainer/HotbarMode" to="." method="_on_hotbar_mode_item_selected"]

--- a/addons/gridmap-plus/dock/Toolbar.gd
+++ b/addons/gridmap-plus/dock/Toolbar.gd
@@ -61,13 +61,13 @@ func _input(event: InputEvent) -> void:
 		return
 	
 	var t = (brush + 1) % mesh_library.get_last_unused_item_id()
+	
 	while t != brush:
 		if GridMapPlus.get_hotbar(mesh_library, t) == hb:
 			brush = t
 			return
 		
 		t = (t + 1) % mesh_library.get_last_unused_item_id()
-
 
 func update_brush() -> void:
 	if !mesh_library:


### PR DESCRIPTION
Hi!

This is the first pull request I do not just to this repo, but to any repo, so please forgive me if I miss anything.

Also I am pretty new to Godot so I might not be following the best practices in the code I added. The changes have been done in part with the help of Claude. For these reasons please feel free to completely discard this pull request or completely change whatever you feel like, without any worries.

**What I added:**

- The Dock UI now shows a "General Options" section that shows even when no mesh item is selected.
![image](https://github.com/user-attachments/assets/1d651f7d-c447-4272-a422-05dd63530a23)

- Now the user can switch between 2 different light types: a directional light (default and the one available until now) and an omni light. Omni lights can be useful for interior design, for example the interior of a big building or a cave.

- Light parameters can be set from the UI. The parameter values are independent for each light type. So you can switch between the two types and it will remember the settings for each (but not after reopening Godot). The parameters are stored in dictionaries.

- The switching between lights and the light parameters adjustment work in real time (you don't need to close the builder to change them). You can also set them before starting the builder window.

Limitations: The lighting settings are not saved. Whenever Godot is restarted all the configuration defaults again to its default values.


**Implementation detalis**

- In order for this to work I add both light types as child of the builder window and I make not visible the one not in use. I think that by making it not visible no resources are being consumed in rendering anything related to that light.

- When the builder window is ready, it sends a signal and the Dock uses that signal to inject the light settings. This means that the light settings are not truly set when the builder starts, but right after it starts. I don't know if this is the best way to do this, but it seemed a decent way of adding it without doing too many changes to the Build.gd code.

- For the UI I tried to respect the way things were implemented, but I did have to change a bit the structure to allow for having both a General options panel and a Mesh options panel
![image](https://github.com/user-attachments/assets/04b13fbe-1de2-4d9f-b6e7-20ab5eab878f)


### Why was this needed?

In my case my game is going to be set in mostly underground caves and similar interior environments. In that kind of setting a directional light is not ideal and for my map scenes I will be using OmniLight3D nodes so it would be very helpful to achieve similar lighting conditions while in the editor, else the colors can be dramatically different.
I believe it can be useful for other creators too.

However I have to say that this still didn't solve my use case, but I think this is due to a different addition that would be needed complementing this one, so I wanted to keep them in separate pull requests.
I anyways explain what is happening to me specifically:

Currently, even with a DirectionalLight3D added to my scene (when just using the Godot editor) I can see my scene with a decent color representation of what the in-game result should be. However when using a very similar lighting in the GridMap+ builder, all I see are the walls that are directly hit by the light, but not other walls (that show 100% black). Not even playiing with angular distance or other parameters can fix this. Here you can see the difference:
![result](https://github.com/user-attachments/assets/9c16d9ec-b1cf-4641-8946-c9ff4972ea0f)

in the Godot editor I have ideal results using an OmniLight3D:
![image](https://github.com/user-attachments/assets/bfda2e0c-0e3f-4c17-a304-164cb0e13a1b)
and with an OmniLight3D, with similar parameters, in GridMap+ I get this:
![result_omni](https://github.com/user-attachments/assets/949260a2-9e16-44fb-a5ae-ea89e939a18f)

I believe this is now related with the rendering and environment options in the viewport that is created with the builder window. Now those options are probably set to the most basic values, which is probably the best for most use cases, but in my case it would benefit from enabling a few options.
If this pull request gets greenlighted I can later on add another pull request for adding those extra rendering/environment options for whoever needs to enable some options at the cost of a performance hit as it seems to be my case.

Looking forward to your comments.